### PR TITLE
chore(dev): gitguardian exclude

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,5 @@
+secret:
+  ignored_matches:
+  - match: db719a87124d834fd9dc3f760a423d0c7635ba69b112144be84d7632b9a3ace8
+    name: X - src/helpers/headerHelper.ts:l.6
+version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ build/
 node_modules/
 
 yarn*
+.cache*
 
 # macOS system files
 .DS_Store


### PR DESCRIPTION
This PR **implements** exclusion for secret of API key in GitGuardian. We want this to be committed for now.